### PR TITLE
Bump actions/checkout to v3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Depending on your needs, you can use a token that will re-trigger workflows
           # See https://github.com/stefanzweifel/git-auto-commit-action#commits-of-this-action-do-not-trigger-new-workflow-runs


### PR DESCRIPTION
## Changes:

- Bump `actions/checkout` to the latest V3 version

## Context:

The README uses an old version of `actions/checkout`. It's probably a good idea to update the example.

Here's the changelog for `actions/checkout` v3.0.0:

> - Updated to the node16 runtime by default
>   - This requires a minimum [Actions Runner](https://github.com/actions/runner/releases/tag/v2.285.0) version of v2.285.0 to run, which is by default available in GHES 3.4 or later.

[^changelog]: https://github.com/actions/checkout/releases/tag/v3.0.0