### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This action helps you easily auto-update your changelog!
 
 ### We all love Dependabot...
 
-But it can feel overwhelming and require additional work to update things like versions and changelogs. 
+But it can feel overwhelming and require additional work to update things like versions and changelogs.
 
 Built around the [Keep-a-Changelog](https://keepachangelog.com/) format, this action looks for an entry line for an updated package and either:
 
-* Add it if not found (including adding the `### Dependencies` and `## [<version>]` sections!)
-* Update it if the package has been upgraded after an initial entry was written
+- Add it if not found (including adding the `### Dependencies` and `## [<version>]` sections!)
+- Update it if the package has been upgraded after an initial entry was written
 
 ### Usage
 
@@ -41,7 +41,7 @@ jobs:
         with:
           # Depending on your needs, you can use a token that will re-trigger workflows
           # See https://github.com/stefanzweifel/git-auto-commit-action#commits-of-this-action-do-not-trigger-new-workflow-runs
-          token: ${{ secrets.GITHUB_TOKEN }} 
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dangoslen/dependabot-changelog-helper@v2
         with:
           version: ${{ needs.setup.outputs.version }}
@@ -69,12 +69,12 @@ This is a way to incrementally build a version over time and only release a vers
 
 #### `changeLogPath`
 
-| Default    | Description                                                        |
-| ---------- | ------------------------------------------------------------------ |
+| Default          | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
 | `./CHANGELOG.md` | The path to the changelog file to add Dependabot entries to. |
 
 #### `activationLabel`
 
-| Default | Description                                            |
-| ------- | ------------------------------------------------------ |
+| Default      | Description                                       |
+| ------------ | ------------------------------------------------- |
 | `dependabot` | The label to indicate that the action should run. |

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 
 ## Dependabot Changelog Helper
 
-### We All Love Dependabot...
-But sometimes it can feel overwhelming and require additional work to update things like versions and changelogs. 
+This action helps you easily auto-update your changelog!
 
-**The purpose of this action is to help you easily manage some of those needs by auto-updating your changelog!**
+### We all love Dependabot...
 
-Built around the [Keep-a-Changelog](https://keepachangelog.com/) format, this action will look for an entry line for an updated package and either
+But it can feel overwhelming and require additional work to update things like versions and changelogs. 
+
+Built around the [Keep-a-Changelog](https://keepachangelog.com/) format, this action looks for an entry line for an updated package and either:
 
 * Add it if not found (including adding the `### Dependencies` and `## [<version>]` sections!)
 * Update it if the package has been upgraded after an initial entry was written
@@ -49,18 +50,31 @@ jobs:
 ```
 
 ### Inputs / Properties
-Below are the properties allowed by the Dependabot Changelog Helper.
+
+Below are the properties you can use for the Dependabot Changelog Helper.
 
 #### `version`
-* Default: `UNRELEASED`
-* The version to find in the changelog to add dependabot entries to.
 
-If the `version` is not found, an unreleased version - matching the pattern `/^## [(unreleased|Unreleased|UNRELEASED)]` - is used. _Either the version you specify or an unreleased version must be present in your changelog or the action will fail._ Many changelogs default to keeping an released version at the top of the changelog as a way to incrementally build a version over time and only release a version once the right changes have been accounted for.
+| Default      | Description                                                        |
+| ------------ | ------------------------------------------------------------------ |
+| `UNRELEASED` | The version to find in the changelog to add Dependabot entries to. |
+
+If the `version` is not found then an unreleased version - matching the pattern `/^## [(unreleased|Unreleased|UNRELEASED)]` - is used.
+
+Many changelogs default to keeping an released version at the top of the changelog.
+This is a way to incrementally build a version over time and only release a version once the right changes have been accounted for.
+
+> **Warning**
+> For the action to work you must have either set a `version` _or_ have an unreleased version in your changelog.
 
 #### `changeLogPath`
-* Default: `./CHANGELOG.md`
-* The path to the changelog file to add dependabot entries to.
+
+| Default    | Description                                                        |
+| ---------- | ------------------------------------------------------------------ |
+| `./CHANGELOG.md` | The path to the changelog file to add Dependabot entries to. |
 
 #### `activationLabel`
-* Default: `dependabot`
-* The label to indicate that the action should run
+
+| Default | Description                                            |
+| ------- | ------------------------------------------------------ |
+| `dependabot` | The label to indicate that the action should run. |


### PR DESCRIPTION
## Changes:

- Split long sentences into smaller sentences
- Use `you` you to put the reader into the text
- Use "one sentence per line" pattern (this makes it easier to move text around)
- Convert lists to tables for the config options
- Put the "marketing slogan" near the top of the readme
- Capitalize proper noun Dependabot
- Run Prettier on the Markdown file
- Use GitHub Flavoured Markdown admonitions

## Context:

Here's a free rewrite. 😉