### PR TITLE
Updating security for pull request workflow; adding contributing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 Thanks for your interest in contributing! This is a very small and specific project - we would like to keep it that way.
 
-If you have an idea for a new feature, please open an [issue](https://github.com/dangoslen/changelog-dependabot-helper/issues/new) first and discuss your idea for enhancement.
+If you have an idea for a new feature, please open an [issue](https://github.com/dangoslen/dependabot-changleog-helper/issues/new) first and discuss your idea for enhancement.
 
-If you have run into a problem, likewise open an [issue](https://github.com/dangoslen/changelog-enforcer/issues/new) and we will address it as best as we see fit. 
+If you have run into a problem, likewise open an [issue](https://github.com/dangoslen/dependabot-changleog-helper/issues/new) and we will address it as best as we see fit. 
 
 ## Development
 
-Currently, this project uses vanilla javascript via `node`. Dependencies are managed via `npm`.
+Currently, this project uses typescript via `node`. Dependencies are managed via `npm`.
 
 ### Installing
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thanks for your interest in contributing! This is a very small and specific project - we would like to keep it that way.
+
+If you have an idea for a new feature, please open an [issue](https://github.com/dangoslen/changelog-dependabot-helper/issues/new) first and discuss your idea for enhancement.
+
+If you have run into a problem, likewise open an [issue](https://github.com/dangoslen/changelog-enforcer/issues/new) and we will address it as best as we see fit. 
+
+## Development
+
+Currently, this project uses vanilla javascript via `node`. Dependencies are managed via `npm`.
+
+### Installing
+
+After cloning this repository, run
+
+```
+npm install
+```
+
+### Building
+```
+npm run package
+```
+
+### Tests
+```
+npm test
+```
+
+This will run `npm lint` and lint code with [ESLint](https://eslint.org/)
+
+### Changelog
+
+Any notable changes to funtionality or updates to dependencies should be added into the [CHANGELOG](../CHANGELOG.md). For an overview of what to write, take a look at the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guide.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,49 +10,48 @@ on:
       - unlabeled
 
 jobs:
-  setup:
+  
+  # validates that the pull request is trusted
+  verify: 
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.read-version.outputs.version  }}
-      tag: ${{ steps.read-version.outputs.tag  }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ACTION_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha }}
+      - run: |
+          VERIFIED_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'verified') }}
+          if [[ ( $VERIFIED_LABEL == 'false' ) ]]; then
+            echo "Pull request is not from a trusted source!"
+            exit 1
+          fi
 
-      - id: read-version
+  # unit tests
+  unit-tests:
+    needs: [ verify ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with: 
+          token: ${{ secrets.ACTION_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - run: npm install
+      - run: npm run test:badges
+      - run: npm run package
+
+      - uses: stefanzweifel/git-auto-commit-action@v4.15.4
+        with:
+          commit_message: "Auto-package action"
+
+  # test action works running from the graph
+  enforce-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with: 
+          token: ${{ secrets.ACTION_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - id: read_version
         run: |
-          echo "::set-output name=version::$(jq -r ".version" package.json)"
-          echo "::set-output name=tag::v$(jq -r ".version" package.json)"
-    
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ACTION_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - run: |
-          npm install
-
-      - run: |
-          npm run all
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Auto commit packaged action"
-
-  changelog:
-    runs-on: ubuntu-latest
-    needs: [ setup ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ACTION_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          echo "version=$(jq -r ".version" package.json)" >> $GITHUB_OUTPUT
+          echo "tag=v$(jq -r ".version" package.json)" >> $GITHUB_OUTPUT
 
       - uses: ./
         with:
@@ -65,12 +64,13 @@ jobs:
       - id: changelog-enforcer
         uses: dangoslen/changelog-enforcer@v2
         with:
-          expectedLatestVersion: ${{ needs.setup.outputs.version }}
+          expectedLatestVersion: ${{ steps.read-version.outputs.version }}
 
+          
       - if: failure()
         uses: unsplash/comment-on-pr@master
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           check_for_duplicate_msg: true
           msg: |
@@ -79,35 +79,23 @@ jobs:
             ```
             ${{ steps.changelog-enforcer.outputs.errorMessage }}
             ```
-            
-  preview-release:
-    runs-on: ubuntu-latest
-    needs: [ setup ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ACTION_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: get changelog entry
-        id: changelog_reader
+      - id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
         with:
-          version: ${{ needs.setup.outputs.version }}
+          version: "${{ steps.read_version.outputs.tag }}"
           path: ./CHANGELOG.md
 
-      - name: check for release
-        id: check_release
+      - id: check_release
         run: |
-          TAG=$(git ls-remote --tags origin | grep ${{ needs.setup.outputs.tag }} || [[ $? == 1 ]] && echo '')
+          TAG=$(git ls-remote --tags origin | grep ${{ steps.read_version.outputs.tag }} | cat )
           MISSING=$([[ -z "$TAG" ]] && echo 'true' || echo 'false')
-          echo ::set-output name=missing::$MISSING
+          echo "missing=$MISSING" >> $GITHUB_OUTPUT
 
-      - name: preview changelog
-        if: ${{ steps.check_release.outputs.missing == 'true' }}
+      - if: ${{ steps.check_release.outputs.missing == 'true' }}
         uses: unsplash/comment-on-pr@master
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           check_for_duplicate_msg: true
           msg: |
@@ -117,4 +105,3 @@ jobs:
               ${{ steps.changelog_reader.outputs.changes }}
 
             </details>
-  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,46 +8,46 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
 
       - name: read versions
         id: read_version
         run: |
-          echo ::set-output name=version::$(jq -r ".version" package.json)
-          echo ::set-output name=tag::v$(jq -r ".version" package.json)
-          echo ::set-output name=major_tag::v$(jq -r ".version" package.json | cut -d '.' -f 1)
-
+          echo "version=$(jq -r ".version" package.json)" >> $GITHUB_OUTPUT
+          echo "tag=v$(jq -r ".version" package.json)"  >> $GITHUB_OUTPUT
+          echo "major_tag=v$(jq -r ".version" package.json | cut -d '.' -f 1)" >> $GITHUB_OUTPUT
         
       - name: read changelog entry for version
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
         with:
-          version: "${{ steps.read_version.outputs.version }}"
+          version: "${{ steps.read_version.outputs.tag }}"
           path: ./CHANGELOG.md
 
       - name: check for existing release
         id: check_release
         run: |
-          TAG=$(git ls-remote --tags origin | grep ${{ steps.read_version.outputs.tag }} || [[ $? == 1 ]] && echo '')
+          TAG=$(git ls-remote --tags origin | grep ${{ steps.read_version.outputs.tag }} | cat)
           MISSING=$([[ -z "$TAG" ]] && echo 'true' || echo 'false')
-          echo ::set-output name=missing::$MISSING
+          echo "missing=$MISSING" >> $GITHUB_OUTPUT
         
       - name: create release
         if: ${{ steps.check_release.outputs.missing == 'true' }}
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "${{ steps.read_version.outputs.tag }}"
-          release_name: Dependabot Changelog Helper ${{ steps.read_version.outputs.version }}
+          release_name: Changelog Dependabot Helper ${{ steps.read_version.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }} 
           draft: false
           prerelease: false
 
       - name: update major version tag
+        if: ${{ steps.check_release.outputs.missing == 'true' }}
         uses: richardsimko/update-tag@v1
         with:
           tag_name: "${{ steps.read_version.outputs.major_tag }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
 
-## [2.1.0]
-
 ### Dependencies
 - Bumps `stefanzweifel/git-auto-commit-action` from 4.14.1 to 4.15.4
 - Bumps `actions/checkout` from 3.0.2 to 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-# Changelog
+# CHANGELOG
+
+Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
+
+## [2.1.0]
+
+### Dependencies
+- Bumps `stefanzweifel/git-auto-commit-action` from 4.14.1 to 4.15.4
+- Bumps `actions/checkout` from 3.0.2 to 3.1.0
 
 ## [2.0.0]
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ But sometimes it can feel overwhelming and require additional work to update thi
 
 **The purpose of this action is to help you easily manage some of those needs by auto-updating your changelog!**
 
-Built around the [Keep-a-Changelog](https://keepachangelog.com/) format, this action will look for an entry line for an updated package and either
+Built around the [KeepAChangelog](https://keepachangelog.com/) format, this action will look for an entry line for an updated package and either
 
 * Add it if not found (including adding the `### Dependencies` and `## [<version>]` sections!)
 * Update it if the package has been upgraded after an initial entry was written


### PR DESCRIPTION
This PR adds the need for a `verified` label before executing the rest of the workflow. Attempts to address part of #104. 