### PR TITLE
Support Rust requirement update PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
+
+### Added
+- Adds support for Dependabot PRs that update Rust dependency requirements
+
 ### Dependencies
 - Bumps `prettier` from 2.3.0 to 2.8.0
 

--- a/__tests__/entry-extractor.test.ts
+++ b/__tests__/entry-extractor.test.ts
@@ -21,6 +21,13 @@ const PULL_REQUEST_EVENT_ALPHA_TO_BETA = {
   }
 }
 
+const PULL_REQUEST_EVENT_RUST_REQUIREMENT_UPDATE = {
+  pull_request: {
+    number: 123,
+    title: 'Update clap requirement from ~2 to ~4'
+  }
+}
+
 test('extracts package and simple number verions', async () => {
   const entry: DependabotEntry = getDependabotEntry(PULL_REQUEST_EVENT)
 
@@ -47,4 +54,14 @@ test('extracts package with odd package name', async () => {
   expect(entry.package).toStrictEqual('@package-with_odd_characters+')
   expect(entry.oldVersion).toStrictEqual('6.0')
   expect(entry.newVersion).toStrictEqual('7.0')
+})
+
+test('extracts package with rust style requirement update', async () => {
+  const entry: DependabotEntry = getDependabotEntry(
+    PULL_REQUEST_EVENT_RUST_REQUIREMENT_UPDATE
+  )
+
+  expect(entry.package).toStrictEqual('clap')
+  expect(entry.oldVersion).toStrictEqual('~2')
+  expect(entry.newVersion).toStrictEqual('~4')
 })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "depenadbot-helper",
+  "name": "dependabot-helper",
   "version": "2.0.0",
   "private": false,
   "description": "A GitHub Action to auto-add dependabot changes to your changelog and increment version numbers",

--- a/src/entry-extractor.ts
+++ b/src/entry-extractor.ts
@@ -1,13 +1,14 @@
 import {WebhookPayload} from '@actions/github/lib/interfaces'
 
 /** Regex explanation
- *                                 --- Matches Bump or Bumps
+ *                                 --- Matches Bump, Bumps, Update or Updates, without capturing it
  *                                 |     --- Matches any non-whitespace character; matching as a few as possible
  *                                 |     |          --- Matches any non-whitespace character
- *                                 |     |          |          --- Matches any non-whitespace character
- *                                 |     |          |          |
+ *                                 |     |          |           --- Matches the text 'requirement ' or nothing, without capturing it
+ *                                 |     |          |           |                --- Matches any non-whitespace character
+ *                                 |     |          |           |                |
  */
-const TITLE_REGEX = new RegExp(/Bumps? (\S+?) from (\S*) to (\S*)/)
+const TITLE_REGEX = new RegExp(/(?:Update|Bump)s? (\S+?) (?:requirement )?from (\S*) to (\S*)/)
 
 export interface DependabotEntry {
   pullRequestNumber: number


### PR DESCRIPTION
Support the naming scheme of dependabot PRs that are updating dependency requirements in Rust projects.
![Screen Shot 2023-01-06 at 12 06 06 PM](https://user-images.githubusercontent.com/1222964/210897087-9e9ffd96-5452-4e23-9a01-0c102f008069.png)
