### PR TITLE
Fix duplicate changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
+### Fixed
+- Fixes an issue where a duplicate entry was added when a previous entry to update was found.
 
 ## [2.2.0]
 ### Added

--- a/__tests__/changelog-updater.test.ts
+++ b/__tests__/changelog-updater.test.ts
@@ -25,9 +25,7 @@ test('adds an entry to the changelog when section already exists with entry', as
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(`# Changelog
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [v1.0.0]
 ### Dependencies
@@ -46,9 +44,7 @@ test('adds an entry to the changelog when section exists under default unrelease
 
   await updateChangelog(PACKAGE_ENTRY, 'nope', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(`# Changelog
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [UNRELEASED]
 ### Dependencies
@@ -66,9 +62,7 @@ test('adds an entry to the changelog when section already exists, but no entry',
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(`# Changelog
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [UNRELEASED]
 ### Dependencies
@@ -86,9 +80,7 @@ test('adds an entry to the changelog when version exists but section does not', 
 
   await updateChangelog(PACKAGE_ENTRY, 'UNRELEASED', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(`# Changelog
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [UNRELEASED]
 ### Dependencies
@@ -111,9 +103,7 @@ test('adds an entry to the changelog - multiple versions', async () => {
 
   await updateChangelog(PACKAGE_ENTRY, 'UNRELEASED', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(`# Changelog
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [UNRELEASED]
 ### Dependencies
@@ -182,9 +172,7 @@ test('updates an entry for an existing package in the same version', async () =>
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(
+  expectWrittenChangelogToBe(
     `# Changelog
 
 ## [v1.0.0]
@@ -204,9 +192,7 @@ test('updates version with new section and entry', async () => {
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(
+  expectWrittenChangelogToBe(
     `# Changelog
 
 ## [v1.0.0]
@@ -232,9 +218,7 @@ test('Does not update lines additional times', async () => {
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(
+  expectWrittenChangelogToBe(
     `# Changelog
 
 ## [v1.0.0]
@@ -267,9 +251,7 @@ test('Updates existing section when sections separated by blank lines', async ()
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(
+  expectWrittenChangelogToBe(
     `# Changelog
 
 ## [v1.0.0]
@@ -308,9 +290,7 @@ test('Adds section when sections separated by blank lines', async () => {
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(
+  expectWrittenChangelogToBe(
     `# Changelog
 
 ## [v1.0.0]
@@ -353,9 +333,7 @@ test('Updates existing section when between other sections', async () => {
 
   await updateChangelog(PACKAGE_ENTRY, 'v1.0.0', './CHANGELOG.md')
 
-  const params = fs.writeFileSync.mock.calls[0]
-  expect(params[0]).toStrictEqual('./CHANGELOG.md')
-  expect(params[1]).toStrictEqual(
+  expectWrittenChangelogToBe(
     `# Changelog
 
 ## [v1.0.0]
@@ -381,4 +359,11 @@ function mockReadStream(changelog: string) {
   fs.createReadStream.mockImplementation((_: PathLike) => {
     return Readable.from([changelog])
   })
+}
+
+function expectWrittenChangelogToBe(changelog: string) {
+  expect(fs.writeFileSync).toBeCalledTimes(1)
+  const params = fs.writeFileSync.mock.calls[0]
+  expect(params[0]).toStrictEqual('./CHANGELOG.md')
+  expect(params[1]).toStrictEqual(changelog)
 }

--- a/src/changelog-updater.ts
+++ b/src/changelog-updater.ts
@@ -55,9 +55,7 @@ async function searchAndUpdateVersion(
 
   if (result.foundEntryToUpdate) {
     updateEntry(entry, changelogPath, result)
-  }
-
-  if (!result.foundDuplicateEntry) {
+  } else if (!result.foundDuplicateEntry) {
     addNewEntry(entry, changelogPath, result)
   }
 


### PR DESCRIPTION
Fixing a duplicate changelog update issue, as seen here: https://github.com/opensearch-project/opensearch-rs/commit/5fa1b65c94d11287a77812c34e93b0fd6bfe25cd#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL18-R19

![Screenshot 2023-02-21 at 9 42 16 AM](https://user-images.githubusercontent.com/1222964/220195627-01e2b31b-366e-4c47-aee2-3677a2157b5c.png)

Changes:
- Expect that fs.writeFileSync is only called once. Otherwise we're only testing the first write to the CHANGELOG, and could be being overwritten.
- Fix changelog update logic so that we only update OR add a new entry, never both.

Test run with just new expect, before logic fix:
<img width="692" alt="Screenshot 2023-02-21 at 9 33 43 AM" src="https://user-images.githubusercontent.com/1222964/220194544-7a278ad0-c854-46b2-97f7-01926e3c20fb.png">
