### PR TITLE
Fix GitHub Actions Annotations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,10 @@ jobs:
       - name: create release
         if: ${{ steps.check_release.outputs.missing == 'true' }}
         id: create_release
-        uses: actions/create-release@v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1.14.0
         with:
-          tag_name: ${{ steps.read_version.outputs.tag }}
-          release_name: Changelog Dependabot Helper ${{ steps.read_version.outputs.version }}
+          tag: ${{ steps.read_version.outputs.tag }}
+          name: Changelog Dependabot Helper ${{ steps.read_version.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }} 
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [UNRELEASED]
+### Changed
+- Fix Github Actions Annotations ([#285](https://github.com/dangoslen/changelog-enforcer/pull/285))
+
 ## [3.10.0]
 
 ### Changed


### PR DESCRIPTION
This is basically the same I did in https://github.com/dangoslen/changelog-enforcer/pull/281

![image](https://github.com/user-attachments/assets/8fe282d2-1c62-4f7d-b783-17ca46ed2ffa)
