### PR TITLE
Replace comment_tag with comment-tag

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          comment_tag: changelog-failure
+          comment-tag: changelog-failure
           mode: upsert
           message: |
             Hey @${{ github.event.pull_request.user.login }}, the Changelog Enforcer failed. Can you take a look at the error below and correct it? Thanks!
@@ -104,7 +104,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          comment_tag: release-notes
+          comment-tag: release-notes
           mode: upsert
           message: |
             <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - Refactors the internal updater to more easily account for multiple entries and formatting ([#311](https://github.com/dangoslen/dependabot-changelog-helper/issues/311))
+- ci: replace comment_tag with comment-tag ([#311](https://github.com/dangoslen/dependabot-changelog-helper/issues/318))
 
 ### Removed
 


### PR DESCRIPTION
## Description and Context
This fixes an "Unexpected input(s)" warning in GitHub Actions I noticed

## Type of Change:
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal changes (changes do not affect functionality, but are an improvement to the codebase)

## Screenshots
![Screenshot From 2025-01-16 21-36-27](https://github.com/user-attachments/assets/aff75c7e-ada2-46e9-a434-16eda7ea1eaa)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I added tests to cover my changes
- [x] All new and existing tests are passing
- [ ] I formatted and linted the code according to repo specs
- [x] I rebased changes with main so that they can be merged easily
- [ ] I have updated the documentation accordingly (if applicable)
