### PR TITLE
Make from oldversion optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
 
+### Changed
+
+- `from <oldVersion>` is now optional in the PR body. If not found, the entry will be added without it.
+
 ### Dependencies
 
 - Bump `@types/node` from 22.14.0 to 22.15.2 ([#366](https://github.com/dangoslen/dependabot-changelog-helper/pull/366))

--- a/__tests__/changelog-updater.test.ts
+++ b/__tests__/changelog-updater.test.ts
@@ -798,6 +798,104 @@ test('adds section when sections separated by blank lines and adds multi package
   )
 })
 
+const CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = `# Changelog
+
+## [v1.0.0]
+### Dependencies
+- Bump \`different-package\` from v1 to v2
+`
+
+test('adds multi package updates properly when a package misses the old version', async () => {
+  mockReadStream(
+    CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
+    )
+
+    await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
+      {
+        pullRequestNumber: 123,
+        repository: 'owner/repo',
+        package: 'other-package',
+        newVersion: 'v2',
+        oldVersion: undefined
+        }
+        ])
+        
+        expectWrittenChangelogToBe(`# Changelog
+
+## [v1.0.0]
+### Dependencies
+- Bump \`different-package\` from v1 to v2
+- Bump \`package\` from v1 to v2 ([#123](https://github.com/owner/repo/pull/123))
+- Bump \`other-package\` to v2 ([#123](https://github.com/owner/repo/pull/123))
+`)
+})
+
+const CHANGELOG_EXISTING_PACKAGE_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = `# Changelog
+
+## [v1.0.0]
+### Dependencies
+- Bump \`different-package\` from v1 to v2
+- Bump \`other-package\` to v1
+`
+
+test('adds multi package updates properly when a package misses the old version', async () => {
+  mockReadStream(
+    CHANGELOG_EXISTING_PACKAGE_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
+    )
+
+    await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
+      {
+        pullRequestNumber: 123,
+        repository: 'owner/repo',
+        package: 'other-package',
+        newVersion: 'v2',
+        oldVersion: undefined
+        }
+        ])
+        
+        expectWrittenChangelogToBe(`# Changelog
+
+## [v1.0.0]
+### Dependencies
+- Bump \`different-package\` from v1 to v2
+- Bump \`other-package\` to v2 ([#123](https://github.com/owner/repo/pull/123))
+- Bump \`package\` from v1 to v2 ([#123](https://github.com/owner/repo/pull/123))
+`)
+})
+
+const CHANGELOG_EXISTING_PACKAGE_WITH_OLD_VERSION_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = `# Changelog
+
+## [v1.0.0]
+### Dependencies
+- Bump \`different-package\` from v1 to v2
+- Bump \`other-package\` from v0 to v1
+`
+
+test('adds multi package updates properly when a package misses the old version', async () => {
+  mockReadStream(
+    CHANGELOG_EXISTING_PACKAGE_WITH_OLD_VERSION_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
+    )
+
+    await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
+      {
+        pullRequestNumber: 123,
+        repository: 'owner/repo',
+        package: 'other-package',
+        newVersion: 'v2',
+        oldVersion: undefined
+        }
+        ])
+        
+        expectWrittenChangelogToBe(`# Changelog
+
+## [v1.0.0]
+### Dependencies
+- Bump \`different-package\` from v1 to v2
+- Bump \`other-package\` from v0 to v2 ([#123](https://github.com/owner/repo/pull/123))
+- Bump \`package\` from v1 to v2 ([#123](https://github.com/owner/repo/pull/123))
+`)
+})
+
 describe('changelog-updater', () => {
   describe('version regex patterns', () => {
     const CHANGELOG_WITH_NOT_YET_RELEASED = `# Changelog

--- a/__tests__/changelog-updater.test.ts
+++ b/__tests__/changelog-updater.test.ts
@@ -851,7 +851,6 @@ test('adds multi package updates properly when entry for an existing package mis
       repository: 'owner/repo',
       package: 'other-package',
       newVersion: 'v2',
-      oldVersion: undefined
     }
   ])
 

--- a/__tests__/changelog-updater.test.ts
+++ b/__tests__/changelog-updater.test.ts
@@ -806,21 +806,19 @@ const CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = `# Changelog
 `
 
 test('adds multi package updates properly when entry for a package misses the old version', async () => {
-  mockReadStream(
-    CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
-    )
+  mockReadStream(CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION)
 
-    await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
-      {
-        pullRequestNumber: 123,
-        repository: 'owner/repo',
-        package: 'other-package',
-        newVersion: 'v2',
-        oldVersion: undefined
-        }
-        ])
-        
-        expectWrittenChangelogToBe(`# Changelog
+  await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
+    {
+      pullRequestNumber: 123,
+      repository: 'owner/repo',
+      package: 'other-package',
+      newVersion: 'v2',
+      oldVersion: undefined
+    }
+  ])
+
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [v1.0.0]
 ### Dependencies
@@ -845,19 +843,19 @@ const CHANGELOG_EXISTING_PACKAGE_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = 
 test('adds multi package updates properly when entry for an existing package misses the old version', async () => {
   mockReadStream(
     CHANGELOG_EXISTING_PACKAGE_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
-    )
+  )
 
-    await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
-      {
-        pullRequestNumber: 123,
-        repository: 'owner/repo',
-        package: 'other-package',
-        newVersion: 'v2',
-        oldVersion: undefined
-        }
-        ])
-        
-        expectWrittenChangelogToBe(`# Changelog
+  await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
+    {
+      pullRequestNumber: 123,
+      repository: 'owner/repo',
+      package: 'other-package',
+      newVersion: 'v2',
+      oldVersion: undefined
+    }
+  ])
+
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [v1.0.0]
 ### Dependencies
@@ -883,19 +881,19 @@ const CHANGELOG_EXISTING_PACKAGE_WITH_OLD_VERSION_ADDS_MULTIPACKAGE_UPDATE_WITHO
 test('adds multi package updates properly when entry for a package with old version misses the old version', async () => {
   mockReadStream(
     CHANGELOG_EXISTING_PACKAGE_WITH_OLD_VERSION_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
-    )
+  )
 
-    await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
-      {
-        pullRequestNumber: 123,
-        repository: 'owner/repo',
-        package: 'other-package',
-        newVersion: 'v2',
-        oldVersion: undefined
-        }
-        ])
-        
-        expectWrittenChangelogToBe(`# Changelog
+  await runUpdate('v1.0.0', './CHANGELOG.md', 'Bump', 'Dependencies', 'none', [
+    {
+      pullRequestNumber: 123,
+      repository: 'owner/repo',
+      package: 'other-package',
+      newVersion: 'v2',
+      oldVersion: undefined
+    }
+  ])
+
+  expectWrittenChangelogToBe(`# Changelog
 
 ## [v1.0.0]
 ### Dependencies

--- a/__tests__/changelog-updater.test.ts
+++ b/__tests__/changelog-updater.test.ts
@@ -805,7 +805,7 @@ const CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = `# Changelog
 - Bump \`different-package\` from v1 to v2
 `
 
-test('adds multi package updates properly when a package misses the old version', async () => {
+test('adds multi package updates properly when entry for a package misses the old version', async () => {
   mockReadStream(
     CHANGELOG_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
     )
@@ -836,9 +836,13 @@ const CHANGELOG_EXISTING_PACKAGE_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION = 
 ### Dependencies
 - Bump \`different-package\` from v1 to v2
 - Bump \`other-package\` to v1
+
+## [v0.0.9]
+### Dependencies
+- Bump \`package\` to v1
 `
 
-test('adds multi package updates properly when a package misses the old version', async () => {
+test('adds multi package updates properly when entry for an existing package misses the old version', async () => {
   mockReadStream(
     CHANGELOG_EXISTING_PACKAGE_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
     )
@@ -860,6 +864,10 @@ test('adds multi package updates properly when a package misses the old version'
 - Bump \`different-package\` from v1 to v2
 - Bump \`other-package\` to v2 ([#123](https://github.com/owner/repo/pull/123))
 - Bump \`package\` from v1 to v2 ([#123](https://github.com/owner/repo/pull/123))
+
+## [v0.0.9]
+### Dependencies
+- Bump \`package\` to v1
 `)
 })
 
@@ -868,10 +876,11 @@ const CHANGELOG_EXISTING_PACKAGE_WITH_OLD_VERSION_ADDS_MULTIPACKAGE_UPDATE_WITHO
 ## [v1.0.0]
 ### Dependencies
 - Bump \`different-package\` from v1 to v2
+- Bump \`package\` from v0 to v1
 - Bump \`other-package\` from v0 to v1
 `
 
-test('adds multi package updates properly when a package misses the old version', async () => {
+test('adds multi package updates properly when entry for a package with old version misses the old version', async () => {
   mockReadStream(
     CHANGELOG_EXISTING_PACKAGE_WITH_OLD_VERSION_ADDS_MULTIPACKAGE_UPDATE_WITHOUT_OLD_VERSION
     )
@@ -891,8 +900,8 @@ test('adds multi package updates properly when a package misses the old version'
 ## [v1.0.0]
 ### Dependencies
 - Bump \`different-package\` from v1 to v2
+- Bump \`package\` from v0 to v2 ([#123](https://github.com/owner/repo/pull/123))
 - Bump \`other-package\` from v0 to v2 ([#123](https://github.com/owner/repo/pull/123))
-- Bump \`package\` from v1 to v2 ([#123](https://github.com/owner/repo/pull/123))
 `)
 })
 

--- a/__tests__/entry-extractor.test.ts
+++ b/__tests__/entry-extractor.test.ts
@@ -262,9 +262,9 @@ describe('the dependabot extractor', () => {
 
   test('extracts multiple entries from body, skipping commits in a list', async () => {
     const entries = extractor.getEntries(PULL_REQUEST_WITH_COMMITS_IN_BODY)
-    
+
     expect(entries).toHaveLength(1)
-    
+
     let entry = entries[0]
     expect(entry.package).toStrictEqual('package')
     expect(entry.repository).toStrictEqual('owner/repo')

--- a/src/changelog-updater.ts
+++ b/src/changelog-updater.ts
@@ -196,11 +196,11 @@ export class DefaultChangelogUpdater implements ChangelogUpdater {
   // We omit PR context - (#pr) - because we can't know which PR merged the previous bump
   private buildEntryLineForDuplicateCheck(entry: VersionEntry): string {
     const lineStart = this.buildEntryLineStart(entry)
-    return `${lineStart} ${entry.oldVersion} to ${entry.newVersion}`
+    return `${lineStart}${entry.oldVersion ? ` from ${entry.oldVersion}` : ''} to ${entry.newVersion}`
   }
 
   private buildEntryLineStart(entry: VersionEntry): string {
-    return `- ${this.entryPrefix} \`${entry.package}\` from`
+    return `- ${this.entryPrefix} \`${entry.package}\``
   }
 
   private buildEntryLine(entry: VersionEntry): string {
@@ -210,7 +210,7 @@ export class DefaultChangelogUpdater implements ChangelogUpdater {
   }
 
   private buildEntryLineStartRegex(entry: VersionEntry): RegExp {
-    return new RegExp(`- \\w+ \`${entry.package}\` from `)
+    return new RegExp(`- \\w+ \`${entry.package}\`(?: from )?`)
   }
 
   private addNewEntry(entry: VersionEntry): void {

--- a/src/changelog-updater.ts
+++ b/src/changelog-updater.ts
@@ -196,7 +196,9 @@ export class DefaultChangelogUpdater implements ChangelogUpdater {
   // We omit PR context - (#pr) - because we can't know which PR merged the previous bump
   private buildEntryLineForDuplicateCheck(entry: VersionEntry): string {
     const lineStart = this.buildEntryLineStart(entry)
-    return `${lineStart}${entry.oldVersion ? ` from ${entry.oldVersion}` : ''} to ${entry.newVersion}`
+    return `${lineStart}${
+      entry.oldVersion ? ` from ${entry.oldVersion}` : ''
+    } to ${entry.newVersion}`
   }
 
   private buildEntryLineStart(entry: VersionEntry): string {

--- a/src/entries/dependabot-extractor.ts
+++ b/src/entries/dependabot-extractor.ts
@@ -11,7 +11,8 @@ export class DependabotExtractor implements EntryExtractor {
      *      --- Matches [Bump, bump, Bumps, bumps, Update, update, Updates or update], without capturing it
      *      |                           --- Matches any non-whitespace character; matching as a few as possible
      *      |                           |          --- Matches any non-whitespace character as the package name
-     *      |                           |          |                   --- Matches any non-whitespace character as the version numbers
+     *      |                           |          |                   --- Matches any non-whitespace character as the old version (optional, "from" might not exist)
+     *      |                           |          |                   |                 --- Matches any non-whitespace character as the new version
      *      |                           |          |                   |                 |
      */
     this.regex = new RegExp(

--- a/src/entries/dependabot-extractor.ts
+++ b/src/entries/dependabot-extractor.ts
@@ -16,7 +16,7 @@ export class DependabotExtractor implements EntryExtractor {
      */
     this.regex = new RegExp(
       // eslint-disable-next-line no-useless-escape
-      /^(?!<li\>).*(?:(?:U|u)pdate|(?:B|b)ump)s? (\S+?) (?:requirement )?from (\S*) to (\S*)/
+      /^(?!<li\>).*(?:(?:U|u)pdate|(?:B|b)ump)s? (\S+?) (?:requirement )?(?:from (\S*) )?to (\S*)/
     )
   }
 

--- a/src/entries/entry-extractor.ts
+++ b/src/entries/entry-extractor.ts
@@ -4,7 +4,7 @@ export interface VersionEntry {
   pullRequestNumber: number
   repository: string | undefined
   package: string
-  oldVersion: string | undefined
+  oldVersion?: string
   newVersion: string
 }
 

--- a/src/entries/entry-extractor.ts
+++ b/src/entries/entry-extractor.ts
@@ -4,7 +4,7 @@ export interface VersionEntry {
   pullRequestNumber: number
   repository: string | undefined
   package: string
-  oldVersion: string
+  oldVersion: string | undefined
   newVersion: string
 }
 


### PR DESCRIPTION
<!--
  Thanks for wanting to contribute to this project!

  To help things move along, provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description and Context
<!-- Describe your changes in detail and provide helpful context.
<!-- Why is this change required? What problem does it solve? -->
### The Problem
When dependabot does not include the old version in its description, there is no "form oldVersion" in the PR body.
<img width="932" height="643" alt="Image" src="https://github.com/user-attachments/assets/8b7115fd-a9d2-4720-9f71-62dcb37eea59" />

This causes the action to fail:

<img width="374" height="239" alt="Image" src="https://github.com/user-attachments/assets/924fa54f-5ea1-4c9b-9704-f7e3c044a758" />


<!-- If it fixes an open issue, please link to the issue here. Other related links are encouraged! -->
### Related issue
Fixes #397

### The fix:
The fix is mostly disussed in the issue. These are the changes made:

- Adjusted the regex pattern in `dependabot-extractor`: Made "from \S* " optional
- Changed the type of `oldVersion` in `entry-extractor`: It is now explicitly `string | undefined`
- Accomodate these changes in `changelog-updater`: Encoded the new pattern into the entry when looking for duplicate


## Type of Change:
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
<!-- If your changes affect how information is displayed or gathered (especially in a UI, report, or CLI), include a screen shot here --->
<!-- Annotated before and after screenshots are encouraged! --->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I added tests to cover my changes
- [x] All new and existing tests are passing
- [x] I formatted and linted the code according to repo specs
- [ ] I rebased changes with main so that they can be merged easily
- [ ] I have updated the documentation accordingly (if applicable)

<!--
    Thanks for adding all that information! 

    Once you open the PR, go through the code yourself and add any comments in places where additional context or clarity might be helpful to reviewers. 
    If you had a hard time choosing between a few different implementation solutions, provide a little context as to why and what other solutions you considered.

    Thanks for helping us keep a smooth and low-friction code review practice!
-->
